### PR TITLE
Only resolve actual paths

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
-const { resolve } = require("path");
+const { resolve, basename } = require("path");
 const { exec } = require("child_process");
 
 exec(
   `npm explore open-science-catalog-validation -- npm run test -- ${process.argv
     .slice(2)
-    .map((p) => resolve(p))
+    .map((p) => p === basename(p) ? p : resolve(p))
     .join(" ")}`,
   (error, stdout) => {
     if (error) {


### PR DESCRIPTION
This PR introduces a fix that checks if the passed string equals `path.basename(string)` in order to find out if the parameter is a path or not.

This enables the usage of e.g. the verbose flag: `open-science-catalog-validation ./eo-missions --verbose`.

Previously, it mistakenly tried to resolve `--verbose` as path.