### PR TITLE
Validate themes instead of osc:themes, minor fixes

### DIFF
--- a/definitions.js
+++ b/definitions.js
@@ -11,8 +11,9 @@ const ROOT_CHILDREN = [
   './projects/catalog.json',
   './themes/catalog.json',
   './variables/catalog.json',
-  './workflows/catalog.json',
-  './experiments/catalog.json'
+// todo: enable once defined
+// './workflows/catalog.json',
+// './experiments/catalog.json'
 ];
 
 const THEMES_SCHEME = 'https://github.com/stac-extensions/osc#theme';

--- a/schemas/collection.json
+++ b/schemas/collection.json
@@ -166,16 +166,8 @@
         "minLength": 1
       }
     },
-    "osc_themes": {
-      "title": "Themes",
-      "type": "array",
-      "format": "osc-themes",
-      "uniqueItems": true,
-      "items": {
-        "type": "string",
-        "format": "osc-theme",
-        "minLength": 1
-      }
+    "themes": {
+      "$ref": "./themes.json"
     }
   }
 }

--- a/schemas/experiments/children.json
+++ b/schemas/experiments/children.json
@@ -45,8 +45,8 @@
             "osc:missions": {
               "$ref": "../collection.json#/definitions/osc_missions"
             },
-            "osc:themes": {
-              "$ref": "../collection.json#/definitions/osc_themes"
+            "themes": {
+              "$ref": "../collection.json#/definitions/themes"
             },
             "osc:variables": {
               "title": "Variables",

--- a/schemas/products/children.json
+++ b/schemas/products/children.json
@@ -42,8 +42,8 @@
         "osc:missions": {
           "$ref": "../collection.json#/definitions/osc_missions"
         },
-        "osc:themes": {
-          "$ref": "../collection.json#/definitions/osc_themes"
+        "themes": {
+          "$ref": "../collection.json#/definitions/themes"
         },
         "osc:variables": {
           "title": "Variables",

--- a/schemas/projects/children.json
+++ b/schemas/projects/children.json
@@ -30,8 +30,8 @@
         "osc:missions": {
           "$ref": "../collection.json#/definitions/osc_missions"
         },
-        "osc:themes": {
-          "$ref": "../collection.json#/definitions/osc_themes"
+        "themes": {
+          "$ref": "../collection.json#/definitions/themes"
         },
         "contacts": {
           "options": {

--- a/schemas/themes.json
+++ b/schemas/themes.json
@@ -1,0 +1,47 @@
+{
+  "type": "array",
+  "format": "osc-themes",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "required": [
+      "concepts",
+      "scheme"
+    ],
+    "properties": {
+      "concepts": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "object",
+          "format": "osc-theme",
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "title": {
+              "type": "string",
+              "minLength": 1
+            },
+            "description": {
+              "type": "string",
+              "minLength": 1
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      },
+      "scheme": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/schemas/workflows/children.json
+++ b/schemas/workflows/children.json
@@ -45,8 +45,8 @@
             "osc:missions": {
               "$ref": "../collection.json#/definitions/osc_missions"
             },
-            "osc:themes": {
-              "$ref": "../collection.json#/definitions/osc_themes"
+            "themes": {
+              "$ref": "../collection.json#/definitions/themes"
             },
             "osc:variables": {
               "title": "Variables",

--- a/validate.js
+++ b/validate.js
@@ -422,6 +422,7 @@ class ValidationRun {
   async checkThemes(data) {
     this.t.truthy(Array.isArray(data.themes), `'themes' must be present as an array`);
     this.t.truthy(typeof data['osc:themes'] === 'undefined', `'osc:themes' must be NOT be present any longer`);
+    this.t.truthy(data.stac_extensions.includes(EXTENSION_SCHEMES.themes), `themes extension must be implemented`);
     const theme = data.themes.find(theme => theme.scheme == THEMES_SCHEME);
     this.t.truthy(theme, `must have theme with scheme '${THEMES_SCHEME}'`);
     this.t.truthy(Array.isArray(theme.concepts), `concepts in themes must be present as an array`);

--- a/validate.js
+++ b/validate.js
@@ -18,6 +18,7 @@ class CustomValidator extends BaseValidator {
     super();
     this.titles = {};
     this.validators = {};
+    this.fileExistsCache = {};
   }
 
   async getValidator(config, filepath) {
@@ -115,6 +116,13 @@ class CustomValidator extends BaseValidator {
     this.registerTitle(report.id, data);
 
     return data;
+  }
+
+  async fileExists(filepath) {
+    if (typeof this.fileExistsCache[filepath] === 'undefined') {
+      this.fileExistsCache[filepath] = await fs.pathExists(filepath);
+    }
+    return this.fileExistsCache[filepath];
   }
 
   async afterValidation(data, test, report, config) {
@@ -277,14 +285,7 @@ class ValidationRun {
     await this.requireParentLink("../catalog.json");
     await this.requireRootLink("../../catalog.json");
 
-    const theme = this.data.themes.find(theme => theme.scheme === THEMES_SCHEME);
-
-    this.t.truthy(theme, `must have theme with scheme '${THEMES_SCHEME}'`);
-
-    const copy = {
-      concepts: theme.concepts.map(concept => concept.id)
-    };
-    await this.checkOscCrossRefArray(copy, "concepts", "themes");
+    await this.checkThemes(this.data);
   }
 
   async validateWorkflow() {
@@ -415,8 +416,29 @@ class ValidationRun {
       await this.checkOscCrossRefArray(this.data, "osc:variables", "variables");
     }
     await this.checkOscCrossRefArray(this.data, "osc:missions", "eo-missions");
-    if (typeof this.data["osc:themes"] !== 'undefined') {
-      await this.checkOscCrossRefArray(this.data, "osc:themes", "themes");
+    await this.checkThemes(this.data);
+  }
+
+  async checkThemes(data) {
+    this.t.truthy(Array.isArray(data.themes), `'themes' must be present as an array`);
+    this.t.truthy(typeof data['osc:themes'] === 'undefined', `'osc:themes' must be NOT be present any longer`);
+    const theme = data.themes.find(theme => theme.scheme == THEMES_SCHEME);
+    this.t.truthy(theme, `must have theme with scheme '${THEMES_SCHEME}'`);
+    this.t.truthy(Array.isArray(theme.concepts), `concepts in themes must be present as an array`);
+    // Check cross references (i.e. whether given theme has a catalog in /themes/)
+    if (Array.isArray(theme.concepts)) {
+      await Promise.all(theme.concepts.map(async (obj) => {
+        const filepath = this.resolve(this.folder, `../../themes/${obj.id}/catalog.json`);
+        const exists = await this.parent.fileExists(filepath);
+        this.t.truthy(exists, `The referenced theme '${obj.id}' must exist at ${filepath}`);
+      }));
+      theme.concepts.forEach((obj) => {
+        const link = data.links.find(link => link.rel === "related" && link.href.endsWith(`/themes/${obj.id}/catalog.json`));
+        this.t.truthy(link, `must have a 'related' link to the theme '${obj.id}'`);
+        if (link) {
+          this.t.truthy(link.type === "application/json", `type of 'related' link to the theme '${obj.id}' must be 'application/json'`);
+        }
+      });
     }
   }
 
@@ -432,8 +454,8 @@ class ValidationRun {
     const slug = this.slugify(value);
     const filename = ['products', 'projects'].includes(type) ? 'collection' : 'catalog';
     const filepath = this.resolve(this.folder, `../../${type}/${slug}/${filename}.json`);
-
-    this.t.truthy(await fs.pathExists(filepath), `The referenced ${type} '${value}' must exist at ${filepath}`);
+    const exists = await await this.parent.fileExists(filepath);
+    this.t.truthy(exists, `The referenced ${type} '${value}' must exist at ${filepath}`);
   }
 
   slugify(value) {


### PR DESCRIPTION
See https://github.com/ESA-EarthCODE/open-science-catalog-metadata/issues/306

Works in combination with https://github.com/ESA-EarthCODE/open-science-catalog-metadata-testing/pull/64