### PR TITLE
Hide record id by default

### DIFF
--- a/schemas/records.json
+++ b/schemas/records.json
@@ -13,7 +13,10 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "A unique identifier of the catalog record."
+          "description": "A unique identifier of the catalog record.",
+          "options": {
+            "hidden": true
+          }
         },
         "type": {
           "type": "string",


### PR DESCRIPTION
Hide Record ID by default. Analogous to: https://github.com/ESA-EarthCODE/open-science-catalog-validation/blob/9188df4a40230d4845d977d02ed0cabfaf913831/schemas/catalog.json#L67-L69