### PR TITLE
Add uuid format to STAC/Record id

### DIFF
--- a/schemas/catalog.json
+++ b/schemas/catalog.json
@@ -64,6 +64,7 @@
     },
     "id": {
       "type": "string",
+      "format": "uuid",
       "options": {
         "hidden": true
       }

--- a/schemas/records.json
+++ b/schemas/records.json
@@ -13,7 +13,8 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "A unique identifier of the catalog record."
+          "description": "A unique identifier of the catalog record.",
+          "format": "uuid"
         },
         "type": {
           "type": "string",


### PR DESCRIPTION
Set default format of "uuid".
Closes https://github.com/ESA-EarthCODE/open-science-catalog-metadata/issues/312