### PR TITLE
chore: harmonize `stac-extensions` analogous to collections

### DIFF
--- a/schemas/catalog.json
+++ b/schemas/catalog.json
@@ -13,14 +13,7 @@
       "$ref": "#/definitions/stac_version"
     },
     "stac_extensions": {
-      "options": {
-        "hidden": true
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/stac_extensions"
-        }
-      ]
+      "$ref": "#/definitions/stac_extensions"
     },
     "id": {
       "$ref": "#/definitions/id"


### PR DESCRIPTION
Analogous to: https://github.com/ESA-EarthCODE/open-science-catalog-validation/blob/9188df4a40230d4845d977d02ed0cabfaf913831/schemas/collection.json#L17-L19