### PR TITLE
chore: replace dereferencing with bundling

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -32,10 +32,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
-      - name: Dereference files
+      - name: Bundle files
         run: |
           npm install && \
-          npm run dereference
+          npm run bundle
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Open Science Catalog requires a certain STAC and Records structure for its entit
 
 These schemas can also be used for e.g. automatically rendering an input form.
 
-To access the schemas in a dereferenced format, use the provided GH pages endpoint, e.g. https://esa-earthcode.github.io/open-science-catalog-validation/schemas/projects/children.json.
+To access the schemas in a bundled format (only internal `$ref`s), use the provided GH pages endpoint, e.g. https://esa-earthcode.github.io/open-science-catalog-validation/schemas/projects/children.json.
 
 # Development
 For development, copy some compatible folder structure into the root folder, then run `npm install` followed by a `npm test`.

--- a/bundle.js
+++ b/bundle.js
@@ -26,7 +26,7 @@ const relativePath = "./schemas";
 const depthRequirement = 1; // Minimum depth for files to be included
 getFilesAtDepth(relativePath, depthRequirement).forEach(async (file) => {
   try {
-    const deref = await $RefParser.dereference(`./${file}`);
+    const deref = await $RefParser.bundle(`./${file}`);
     fs.writeFile(file, JSON.stringify(deref), (err) => {
       if (err) console.log(err);
       else {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "stac-node-validator": "2.0.0-beta.15"
   },
   "scripts": {
-    "dereference": "node ./dereference.js",
+    "bundle": "node ./bundle.js",
     "test": "stac-node-validator --config config.js"
   }
 }


### PR DESCRIPTION
This replaces `dereference` with `bundle` in order to prevent issues with circular `$ref`s (see https://apitools.dev/json-schema-ref-parser/docs/).
This keeps the `$ref`s, but turns them from external to interal, for easier usage in various tools.

Closes #19.