### PR TITLE
fix: force map & drawtool projections for GUI schema

### DIFF
--- a/schemas/collection.json
+++ b/schemas/collection.json
@@ -107,7 +107,15 @@
                 "minItems": 4,
                 "maxItems": 4
               },
-              "minItems": 1
+              "minItems": 1,
+              "options": {
+                "map": {
+                  "projection": "EPSG:3857"
+                },
+                "drawtools": {
+                  "projection": "EPSG:4326"
+                }
+              }
             }
           }
         },


### PR DESCRIPTION
This PR forces the map to `EPSG:3857` (in order to align with the map inside the STAC Browser preview) and the output of the bbox drawings to `EPSG:4326` (in order to align with the actual required output for STAC).