### PR TITLE
fix: change summaries type to object

### DIFF
--- a/schemas/collection.json
+++ b/schemas/collection.json
@@ -52,7 +52,7 @@
     },
     "summaries": {
       "$comment": "Currently unused by OSC catalog",
-      "type": "array",
+      "type": "object",
       "options": {
         "hidden": true
       }


### PR DESCRIPTION
Closes https://github.com/ESA-EarthCODE/open-science-catalog-validation/issues/38